### PR TITLE
Allowing function expressions in partition_by for ducklake

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,4 +1,5 @@
 import os
+import re
 import traceback
 from collections import defaultdict
 from dataclasses import dataclass
@@ -52,6 +53,59 @@ if TYPE_CHECKING:
     import agate
 
 logger = AdapterLogger("DuckDB")
+
+
+_PARTITION_TRANSFORM_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PARTITION_INJECTION_TOKENS = (";", "--")
+
+
+def _render_partition_part(raw: str) -> str:
+    """Render a single ``partitioned_by`` entry to SQL.
+
+    A bare value (no parentheses) is treated as an identifier and double-quoted.
+    A value containing parentheses is treated as a transform expression
+    (e.g. ``day(ts)``, ``bucket(16, "user_id")``); the function name is shape-
+    checked, the inner content is passed through verbatim, and quoting of any
+    column reference inside the parens is the user's responsibility.
+    """
+    s = raw.strip()
+    if not s:
+        raise DbtRuntimeError("partitioned_by entry must be a non-empty string")
+
+    if "(" in s:
+        if not s.endswith(")"):
+            raise DbtRuntimeError(
+                f"Invalid partitioned_by entry {raw!r}: unbalanced parentheses"
+            )
+        name, _, rest = s.partition("(")
+        name = name.strip()
+        if not _PARTITION_TRANSFORM_NAME_RE.match(name):
+            raise DbtRuntimeError(
+                f"Invalid partitioned_by transform name {name!r} in {raw!r}"
+            )
+        inner = rest[:-1]
+        for token in _PARTITION_INJECTION_TOKENS:
+            if token in inner:
+                raise DbtRuntimeError(
+                    f"Invalid partitioned_by entry {raw!r}: contains {token!r}"
+                )
+        depth = 0
+        for ch in inner:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth < 0:
+                    raise DbtRuntimeError(
+                        f"Invalid partitioned_by entry {raw!r}: unbalanced parentheses"
+                    )
+        if depth != 0:
+            raise DbtRuntimeError(
+                f"Invalid partitioned_by entry {raw!r}: unbalanced parentheses"
+            )
+        return f"{name}({inner})"
+
+    return '"' + s.replace('"', '""') + '"'
 
 
 @dataclass
@@ -150,6 +204,10 @@ class DuckDBAdapter(SQLAdapter):
             return False
 
         return relation.database in self.config.credentials._ducklake_dbs
+
+    @available
+    def render_partition_part(self, raw: str) -> str:
+        return _render_partition_part(raw)
 
     @available
     def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -64,10 +64,10 @@
   {%- endif -%}
 
   {%- set raw = config.get('partitioned_by', none) -%}
-  {%- if raw is none -%}
+  {%- if raw is none or raw == '' -%}
     {%- set raw = config.get('partition_by', none) -%}
   {%- endif -%}
-  {%- if raw is none -%}
+  {%- if raw is none or raw == '' -%}
     {{ return(none) }}
   {%- endif -%}
 
@@ -91,12 +91,11 @@
     {{ return(none) }}
   {%- endif -%}
 
-  {%- set quoted = [] -%}
+  {%- set rendered = [] -%}
   {%- for col in parts -%}
-    {%- set escaped = col | replace('"', '""') -%}
-    {%- do quoted.append(adapter.quote(escaped)) -%}
+    {%- do rendered.append(adapter.render_partition_part(col)) -%}
   {%- endfor -%}
-  {{ return(quoted | join(', ')) }}
+  {{ return(rendered | join(', ')) }}
 {%- endmacro %}
 
 

--- a/tests/functional/adapter/test_ducklake_partitioned_by.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by.py
@@ -35,6 +35,18 @@ models__partitioned_by_time_parts = """
 {{ render_create_table_as("select 1 as event_day, 2 as event_month, 3 as event_year, 4 as event_hour") }}
 """
 
+models__partitioned_by_transform = """
+{{ config(materialized='view', partitioned_by=['day(ts)', 'region']) }}
+
+{{ render_create_table_as("select TIMESTAMP '2024-01-01' as ts, 'us' as region") }}
+"""
+
+models__partitioned_by_bucket_transform = """
+{{ config(materialized='view', partitioned_by=['bucket(16, user_id)']) }}
+
+{{ render_create_table_as("select 1 as user_id") }}
+"""
+
 models__partitioned_by_python = """
 {{ config(materialized='view', partitioned_by='ds') }}
 
@@ -112,6 +124,8 @@ class BasePartitionedByCompile:
             "partitioned_by_python.sql": models__partitioned_by_python,
             "contract_partitioned_by.sql": models__contract_partitioned_by,
             "partitioned_by_time_parts.sql": models__partitioned_by_time_parts,
+            "partitioned_by_transform.sql": models__partitioned_by_transform,
+            "partitioned_by_bucket_transform.sql": models__partitioned_by_bucket_transform,
             "schema.yml": schema_yml,
         }
 
@@ -168,6 +182,24 @@ class TestDucklakePartitionedByCompile(BasePartitionedByCompile):
             re.IGNORECASE | re.DOTALL,
         )
 
+    def test_partitioned_by_transform(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_by_transform", "sql")
+        assert re.search(
+            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*day\(ts\)\s*,\s*"region"\s*\)',
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+    def test_partitioned_by_bucket_transform(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_by_bucket_transform", "sql")
+        assert re.search(
+            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*bucket\(16,\s*user_id\)\s*\)',
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
 
 class TestNonDucklakePartitionedByCompile(BasePartitionedByCompile):
     @pytest.fixture(scope="class")
@@ -183,11 +215,15 @@ class TestNonDucklakePartitionedByCompile(BasePartitionedByCompile):
         sql_incremental = read_compiled_file(project, "partition_by_incremental", "sql").lower()
         sql_contract = read_compiled_file(project, "contract_partitioned_by", "sql").lower()
         sql_time_parts = read_compiled_file(project, "partitioned_by_time_parts", "sql").lower()
+        sql_transform = read_compiled_file(project, "partitioned_by_transform", "sql").lower()
+        sql_bucket = read_compiled_file(project, "partitioned_by_bucket_transform", "sql").lower()
         python_code = read_compiled_file(project, "partitioned_by_python", "sql").lower()
         assert "set partitioned by" not in sql_table
         assert "set partitioned by" not in sql_incremental
         assert "set partitioned by" not in sql_contract
         assert "set partitioned by" not in sql_time_parts
+        assert "set partitioned by" not in sql_transform
+        assert "set partitioned by" not in sql_bucket
         assert "set partitioned by" not in python_code
 
 

--- a/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
@@ -73,6 +73,14 @@ models__invalid_partitioned_by_string = """
 select 1 as ds, 'a' as value
 """
 
+models__transform_partitioned_model = """
+{{ config(materialized='table', database='ducklake_db', partitioned_by=['day(ts)', 'region']) }}
+
+select TIMESTAMP '2025-01-01 00:00:00' as ts, 'us' as region, 1 as id
+union all
+select TIMESTAMP '2025-01-02 00:00:00' as ts, 'eu' as region, 2 as id
+"""
+
 
 def get_partition_columns(project, model_name, schema_name):
     relation = project.adapter.Relation.create(
@@ -99,6 +107,33 @@ def get_partition_columns(project, model_name, schema_name):
         order by c.column_id
     """
     return [row[0].lower() for row in project.run_sql(query, fetch="all")]
+
+
+def get_partition_columns_with_transforms(project, model_name, schema_name):
+    relation = project.adapter.Relation.create(
+        database="ducklake_db",
+        schema=schema_name,
+        identifier=model_name,
+    )
+    metadata_schema = "__ducklake_metadata_ducklake_db"
+    query = f"""
+        select c.column_name, pc.transform
+        from {metadata_schema}.ducklake_partition_column pc
+        join {metadata_schema}.ducklake_column c
+          on c.table_id = pc.table_id
+         and c.column_id = pc.column_id
+        join {metadata_schema}.ducklake_table t
+          on t.table_id = c.table_id
+        join {metadata_schema}.ducklake_schema s
+          on s.schema_id = t.schema_id
+        where lower(t.table_name) = lower('{relation.identifier}')
+          and lower(s.schema_name) = lower('{relation.schema}')
+          and t.end_snapshot is null
+          and c.end_snapshot is null
+          and s.end_snapshot is null
+        order by c.column_id
+    """
+    return [(row[0].lower(), row[1]) for row in project.run_sql(query, fetch="all")]
 
 
 @pytest.mark.requires_ducklake
@@ -137,6 +172,7 @@ class TestDucklakePartitionedByIntegration(BaseDucklakePartitionedBy):
             "table_partitioned_model.sql": models__table_partitioned_model,
             "incremental_partitioned_model.sql": models__incremental_partitioned_model,
             "python_partitioned_model.py": models__python_partitioned_model,
+            "transform_partitioned_model.sql": models__transform_partitioned_model,
         }
 
     def test_table_partitioned_by_sets_partition_columns(self, project):
@@ -168,6 +204,18 @@ class TestDucklakePartitionedByIntegration(BaseDucklakePartitionedBy):
         result = run_dbt(["run", "--select", "python_partitioned_model"], expect_pass=True)
         schema = result.results[0].node.schema
         assert get_partition_columns(project, "python_partitioned_model", schema) == ["ds"]
+
+    def test_table_partitioned_by_transform_sets_partition_columns(self, project):
+        result = run_dbt(["run", "--select", "transform_partitioned_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        partitions = get_partition_columns_with_transforms(
+            project, "transform_partitioned_model", schema
+        )
+        column_names = [p[0] for p in partitions]
+        transforms = [str(p[1]).lower() for p in partitions]
+        assert column_names == ["ts", "region"]
+        assert "day" in transforms[0]
+        assert transforms[1] in ("identity", "none", "")
 
 
 @pytest.mark.skip_profile("buenavista")

--- a/tests/unit/test_partition_render.py
+++ b/tests/unit/test_partition_render.py
@@ -1,0 +1,45 @@
+import pytest
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.duckdb.impl import _render_partition_part
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("col1", '"col1"'),
+        ("time field", '"time field"'),
+        ('with"quote', '"with""quote"'),
+        ("day(ts)", "day(ts)"),
+        ('day("ts")', 'day("ts")'),
+        ('day("time field")', 'day("time field")'),
+        ("bucket(16, user_id)", "bucket(16, user_id)"),
+        ('bucket(16, "user_id")', 'bucket(16, "user_id")'),
+        ("  day(ts)  ", "day(ts)"),
+        ("Day(TS)", "Day(TS)"),
+        ("quarter(ts)", "quarter(ts)"),
+    ],
+)
+def test_render_partition_part_ok(raw, expected):
+    assert _render_partition_part(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "day(ts",
+        "day(ts))",
+        "day(ts); drop table x; --",
+        "day(ts) -- comment",
+        "day(ts; drop table x;)",
+        "day(ts) drop table x",
+        "1day(ts)",
+        "day-fn(ts)",
+        "(ts)",
+    ],
+)
+def test_render_partition_part_rejected(raw):
+    with pytest.raises(DbtRuntimeError):
+        _render_partition_part(raw)


### PR DESCRIPTION
In ducklake one can use a few partitioning functions like `month(ts)`.
These were assumed to be columns and escaped, but that caused DuckLake to treat them as literal columns called `"month(ts)"`

The new logic looks for parenthesis and doesn't scape if so. To make up for the relaxed security, it ensures there are no SQL break tactics. If the column still needs escaping people can do that themselves. eg `month("time field")`