### PR TITLE
Omit unnecessary CASCADE when dropping relations

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -297,11 +297,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if adapter.is_ducklake(relation) %}
-      drop {{ relation.type }} if exists {{ relation }}
-    {% else %}
-      drop {{ relation.type }} if exists {{ relation }} cascade
-    {% endif %}
+    drop {{ relation.type }} if exists {{ relation }}
   {%- endcall %}
 {% endmacro %}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.4.4
+    duckdb==1.5.2
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --profile=md --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
 deps =
-  duckdb==1.4.4
+  duckdb==1.5.2
   -rdev-requirements.txt
   -e.[md]
 


### PR DESCRIPTION
DuckLake will throw an error if you try to drop a table with CASCADE.
However, it turns out this is unnecessary for DuckDB as well. DuckDB has no dependent objects against views or tables. See:

https://duckdb.org/docs/lts/sql/statements/drop

<img width="461" height="416" alt="image" src="https://github.com/user-attachments/assets/e4e26cf6-0bac-4346-a5a4-f3de54a48a55" />

