### PR TITLE
Allow DuckLake partition functions in `partition_by`

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,8 @@ select
 from {{ ref('upstream_model') }}
 ```
 
+Each `partitioned_by` entry is rendered as written, so quote identifiers in the config when needed, for example `partitioned_by=['"field name"', 'day("event time")']`. DuckDB/DuckLake validates which partition functions and arguments are supported.
+
 DuckLake applies these via `ALTER TABLE ... SET PARTITIONED BY (...)` and `ALTER TABLE ... SET SORTED BY (...)`, and they only affect new data. For first builds and full refreshes, dbt-duckdb creates an empty table, sets partitioning and/or sort order, then inserts data so the initial load is laid out as configured. For incremental runs that only insert/update, no ALTER is issued. See the DuckLake docs for [partitioning](https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning) and [sorted tables](https://ducklake.select/docs/stable/duckdb/advanced_features/sorted_tables).
 
 Example partitions (day, month, year, hour):

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -64,10 +64,10 @@
   {%- endif -%}
 
   {%- set raw = config.get('partitioned_by', none) -%}
-  {%- if raw is none -%}
+  {%- if raw is none or raw == '' -%}
     {%- set raw = config.get('partition_by', none) -%}
   {%- endif -%}
-  {%- if raw is none -%}
+  {%- if raw is none or raw == '' -%}
     {{ return(none) }}
   {%- endif -%}
 
@@ -91,12 +91,7 @@
     {{ return(none) }}
   {%- endif -%}
 
-  {%- set quoted = [] -%}
-  {%- for col in parts -%}
-    {%- set escaped = col | replace('"', '""') -%}
-    {%- do quoted.append(adapter.quote(escaped)) -%}
-  {%- endfor -%}
-  {{ return(quoted | join(', ')) }}
+  {{ return(parts | join(', ')) }}
 {%- endmacro %}
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ testpaths =
     tests/unit
 markers =
     skip_profile(profile)
+    requires_ducklake

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.4.4
+    duckdb==1.5.2
 
 [files]
 packages =

--- a/tests/functional/adapter/test_ducklake_partitioned_by.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by.py
@@ -35,6 +35,24 @@ models__partitioned_by_time_parts = """
 {{ render_create_table_as("select 1 as event_day, 2 as event_month, 3 as event_year, 4 as event_hour") }}
 """
 
+models__partitioned_by_transform = """
+{{ config(materialized='view', partitioned_by=['day(ts)', '"region"']) }}
+
+{{ render_create_table_as("select TIMESTAMP '2024-01-01' as ts, 'us' as region") }}
+"""
+
+models__partitioned_by_quoted_identifier = """
+{{ config(materialized='view', partitioned_by='"field name"') }}
+
+{{ render_create_table_as('select 1 as "field name"') }}
+"""
+
+models__partitioned_by_bucket_transform = """
+{{ config(materialized='view', partitioned_by=['bucket(16, user_id)']) }}
+
+{{ render_create_table_as("select 1 as user_id") }}
+"""
+
 models__partitioned_by_python = """
 {{ config(materialized='view', partitioned_by='ds') }}
 
@@ -96,6 +114,17 @@ def read_compiled_file(project, model_name, extension):
     return matches[0].read_text()
 
 
+def normalize_sql(sql):
+    return " ".join(sql.split())
+
+
+def assert_set_partitioned_by(sql, expected):
+    assert re.search(
+        f"alter table(.*)set partitioned by \\({re.escape(expected)}\\)",
+        normalize_sql(sql),
+    )
+
+
 class BasePartitionedByCompile:
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -112,6 +141,9 @@ class BasePartitionedByCompile:
             "partitioned_by_python.sql": models__partitioned_by_python,
             "contract_partitioned_by.sql": models__contract_partitioned_by,
             "partitioned_by_time_parts.sql": models__partitioned_by_time_parts,
+            "partitioned_by_transform.sql": models__partitioned_by_transform,
+            "partitioned_by_bucket_transform.sql": models__partitioned_by_bucket_transform,
+            "partitioned_by_quoted_identifier.sql": models__partitioned_by_quoted_identifier,
             "schema.yml": schema_yml,
         }
 
@@ -134,39 +166,42 @@ class TestDucklakePartitionedByCompile(BasePartitionedByCompile):
     def test_partitioned_by_string(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "partitioned_by_table", "sql")
-        assert re.search(r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+        assert_set_partitioned_by(sql, "ds")
 
     def test_partition_by_list(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "partition_by_incremental", "sql")
-        assert re.search(
-            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*,\s*"region"\s*\)',
-            sql,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_set_partitioned_by(sql, "ds, region")
 
     def test_partitioned_by_python(self, project):
         run_dbt(["compile"])
         python_code = read_compiled_file(project, "partitioned_by_python", "sql")
-        assert re.search(
-            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*\)',
-            python_code,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_set_partitioned_by(python_code, "ds")
 
     def test_partitioned_by_contract(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "contract_partitioned_by", "sql")
-        assert re.search(r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+        assert_set_partitioned_by(sql, "ds")
 
     def test_partitioned_by_time_parts(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "partitioned_by_time_parts", "sql")
-        assert re.search(
-            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"event_day"\s*,\s*"event_month"\s*,\s*"event_year"\s*,\s*"event_hour"\s*\)',
-            sql,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_set_partitioned_by(sql, "event_day, event_month, event_year, event_hour")
+
+    def test_partitioned_by_quoted_identifier(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_by_quoted_identifier", "sql")
+        assert_set_partitioned_by(sql, '"field name"')
+
+    def test_partitioned_by_transform(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_by_transform", "sql")
+        assert_set_partitioned_by(sql, 'day(ts), "region"')
+
+    def test_partitioned_by_bucket_transform(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_by_bucket_transform", "sql")
+        assert_set_partitioned_by(sql, "bucket(16, user_id)")
 
 
 class TestNonDucklakePartitionedByCompile(BasePartitionedByCompile):
@@ -183,11 +218,17 @@ class TestNonDucklakePartitionedByCompile(BasePartitionedByCompile):
         sql_incremental = read_compiled_file(project, "partition_by_incremental", "sql").lower()
         sql_contract = read_compiled_file(project, "contract_partitioned_by", "sql").lower()
         sql_time_parts = read_compiled_file(project, "partitioned_by_time_parts", "sql").lower()
+        sql_transform = read_compiled_file(project, "partitioned_by_transform", "sql").lower()
+        sql_bucket = read_compiled_file(project, "partitioned_by_bucket_transform", "sql").lower()
+        sql_quoted = read_compiled_file(project, "partitioned_by_quoted_identifier", "sql").lower()
         python_code = read_compiled_file(project, "partitioned_by_python", "sql").lower()
         assert "set partitioned by" not in sql_table
         assert "set partitioned by" not in sql_incremental
         assert "set partitioned by" not in sql_contract
         assert "set partitioned by" not in sql_time_parts
+        assert "set partitioned by" not in sql_transform
+        assert "set partitioned by" not in sql_bucket
+        assert "set partitioned by" not in sql_quoted
         assert "set partitioned by" not in python_code
 
 

--- a/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
@@ -67,10 +67,12 @@ models__empty_partitioned_by_list = """
 select 1 as ds, 'a' as value
 """
 
-models__invalid_partitioned_by_string = """
-{{ config(materialized='table', database='ducklake_db', partitioned_by='ds); drop table x; --') }}
+models__transform_partitioned_model = """
+{{ config(materialized='table', database='ducklake_db', partitioned_by=['day(ts)', 'region']) }}
 
-select 1 as ds, 'a' as value
+select TIMESTAMP '2025-01-01 00:00:00' as ts, 'us' as region, 1 as id
+union all
+select TIMESTAMP '2025-01-02 00:00:00' as ts, 'eu' as region, 2 as id
 """
 
 
@@ -99,6 +101,33 @@ def get_partition_columns(project, model_name, schema_name):
         order by c.column_id
     """
     return [row[0].lower() for row in project.run_sql(query, fetch="all")]
+
+
+def get_partition_columns_with_transforms(project, model_name, schema_name):
+    relation = project.adapter.Relation.create(
+        database="ducklake_db",
+        schema=schema_name,
+        identifier=model_name,
+    )
+    metadata_schema = "__ducklake_metadata_ducklake_db"
+    query = f"""
+        select c.column_name, pc.transform
+        from {metadata_schema}.ducklake_partition_column pc
+        join {metadata_schema}.ducklake_column c
+          on c.table_id = pc.table_id
+         and c.column_id = pc.column_id
+        join {metadata_schema}.ducklake_table t
+          on t.table_id = c.table_id
+        join {metadata_schema}.ducklake_schema s
+          on s.schema_id = t.schema_id
+        where lower(t.table_name) = lower('{relation.identifier}')
+          and lower(s.schema_name) = lower('{relation.schema}')
+          and t.end_snapshot is null
+          and c.end_snapshot is null
+          and s.end_snapshot is null
+        order by c.column_id
+    """
+    return [(row[0].lower(), row[1]) for row in project.run_sql(query, fetch="all")]
 
 
 @pytest.mark.requires_ducklake
@@ -137,6 +166,7 @@ class TestDucklakePartitionedByIntegration(BaseDucklakePartitionedBy):
             "table_partitioned_model.sql": models__table_partitioned_model,
             "incremental_partitioned_model.sql": models__incremental_partitioned_model,
             "python_partitioned_model.py": models__python_partitioned_model,
+            "transform_partitioned_model.sql": models__transform_partitioned_model,
         }
 
     def test_table_partitioned_by_sets_partition_columns(self, project):
@@ -169,6 +199,18 @@ class TestDucklakePartitionedByIntegration(BaseDucklakePartitionedBy):
         schema = result.results[0].node.schema
         assert get_partition_columns(project, "python_partitioned_model", schema) == ["ds"]
 
+    def test_table_partitioned_by_transform_sets_partition_columns(self, project):
+        result = run_dbt(["run", "--select", "transform_partitioned_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        partitions = get_partition_columns_with_transforms(
+            project, "transform_partitioned_model", schema
+        )
+        column_names = [p[0] for p in partitions]
+        transforms = [str(p[1]).lower() for p in partitions]
+        assert column_names == ["ts", "region"]
+        assert "day" in transforms[0]
+        assert transforms[1] in ("identity", "none", "")
+
 
 @pytest.mark.skip_profile("buenavista")
 class TestNonDucklakePartitionedBy:
@@ -195,7 +237,6 @@ class TestPartitionedByValidation(BaseDucklakePartitionedBy):
         return {
             "invalid_partitioned_by.sql": models__invalid_partitioned_by,
             "empty_partitioned_by_list.sql": models__empty_partitioned_by_list,
-            "invalid_partitioned_by_string.sql": models__invalid_partitioned_by_string,
         }
 
     def test_partitioned_by_list_values_must_be_strings(self, project):
@@ -210,9 +251,3 @@ class TestPartitionedByValidation(BaseDucklakePartitionedBy):
         assert "partitioned_by/partition_by must contain at least one column" in str(
             result.results[0].message
         )
-
-    def test_partitioned_by_invalid_string_rejected_by_duckdb(self, project):
-        """Invalid identifier is quoted and DuckDB rejects it as a nonexistent column."""
-        result = run_dbt(["run", "--select", "invalid_partitioned_by_string"], expect_pass=False)
-        assert "does not exist" in str(result.results[0].message)
-

--- a/tests/functional/adapter/test_ducklake_sorted_by.py
+++ b/tests/functional/adapter/test_ducklake_sorted_by.py
@@ -98,6 +98,25 @@ def read_compiled_file(project, model_name, extension):
     return matches[0].read_text()
 
 
+def normalize_sql(sql):
+    return " ".join(sql.split())
+
+
+def assert_set_sorted_by(sql, expected):
+    assert re.search(
+        f"alter table(.*)set sorted by \\({re.escape(expected)}\\)",
+        normalize_sql(sql),
+    )
+
+
+def assert_partitioned_before_sorted(sql, partitioned_by, sorted_by):
+    assert re.search(
+        f"alter table(.*)set partitioned by \\({re.escape(partitioned_by)}\\)"
+        f"(.*)alter table(.*)set sorted by \\({re.escape(sorted_by)}\\)",
+        normalize_sql(sql),
+    )
+
+
 class BaseSortedByCompile:
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -136,41 +155,27 @@ class TestDucklakeSortedByCompile(BaseSortedByCompile):
     def test_sorted_by_string(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "sorted_by_table", "sql")
-        assert re.search(r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+        assert_set_sorted_by(sql, '"ds"')
 
     def test_sort_by_list(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "sort_by_incremental", "sql")
-        assert re.search(
-            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*,\s*"region"\s*\)',
-            sql,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_set_sorted_by(sql, '"ds", "region"')
 
     def test_sorted_by_python(self, project):
         run_dbt(["compile"])
         python_code = read_compiled_file(project, "sorted_by_python", "sql")
-        assert re.search(
-            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)',
-            python_code,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_set_sorted_by(python_code, '"ds"')
 
     def test_sorted_by_contract(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "contract_sorted_by", "sql")
-        assert re.search(r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+        assert_set_sorted_by(sql, '"ds"')
 
     def test_partitioned_and_sorted_together(self, project):
         run_dbt(["compile"])
         sql = read_compiled_file(project, "partitioned_and_sorted", "sql")
-        # Both ALTERs should appear, with partitioned before sorted.
-        assert re.search(
-            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*\).*'
-            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"region"\s*\)',
-            sql,
-            re.IGNORECASE | re.DOTALL,
-        )
+        assert_partitioned_before_sorted(sql, "ds", '"region"')
 
 
 class TestNonDucklakeSortedByCompile(BaseSortedByCompile):

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --profile=md --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
 deps =
-  duckdb==1.4.4
+  duckdb==1.5.2
   -rdev-requirements.txt
   -e.[md]
 


### PR DESCRIPTION
Currently we pass the contents of `partition_by` for sql escaping, assuming it's always a column identifier.
However ducklake allows for several partition functions, which no longer are interpreted as such if escaped.
https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning

 * day/hour/month/year(ts) etc time expressions
 * bucket(n, col) hash bucketing
 
 
 