### PR TITLE
Narrow exception swallowing to just unexpected COMMIT

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -312,9 +311,14 @@ class DuckDBAdapter(SQLAdapter):
             self.connections.commit_if_has_connection()
         except DbtInternalError as e:
             # Log commit errors instead of silently swallowing them to aid debugging
-            logger.warning(f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}")
-            # Still pass to maintain backward compatibility, but now with visibility
-            pass
+            message = str(e)
+            if (
+                "Tried to commit transaction on connection" in message
+                and "but it does not have one open" in message
+            ):
+                logger.warning(f"(warning) {message}")
+            else:
+                raise
 
     def submit_python_job(self, parsed_model: dict, compiled_code: str) -> AdapterResponse:
         connection = self.connections.get_if_exists()


### PR DESCRIPTION
This exception block was turning all DbtInternalErrors into warnings, which seems like overreach. We many things can cause DbtinternalErrors and we want to stop on those.

This downgrades it to just catch `Tried to commit transaction on connection` errors, which happen when a `COMMIT  ` does not follow a `BEGIN` on a given connection. While this shouldn't happen, this PR is just to improve the current situation. 