### PR TITLE
Bump DuckDB pin to 1.5.2 for MotherDuck Tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.4.4
+    duckdb==1.5.2
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --profile=md --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
 deps =
-  duckdb==1.4.4
+  duckdb==1.5.2
   -rdev-requirements.txt
   -e.[md]
 


### PR DESCRIPTION
Bumps the DuckDB version used by the MotherDuck test extra and tox env from 1.4.4 to 1.5.2.