### PR TITLE
Run persist docs tests on MotherDuck

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.4.4
+    duckdb==1.5.2
 
 [files]
 packages =

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -7,22 +7,19 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 )
 from dbt.tests.util import run_dbt
 
-@pytest.mark.skip_profile("md")
 class TestPersistDocs(BasePersistDocs):
     pass
 
 
-@pytest.mark.skip_profile("md")
 class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
     pass
 
 
-@pytest.mark.skip_profile("md")
 class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
     pass
 
 @pytest.mark.requires_ducklake
-@pytest.mark.skip_profile("md", "buenavista")
+@pytest.mark.skip_profile("buenavista")
 class TestDuckLakePersistDocsTransactions:
     @pytest.fixture(scope="class")
     def ducklake_paths(self, tmp_path_factory):

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --profile=md --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
 deps =
-  duckdb==1.4.4
+  duckdb==1.5.2
   -rdev-requirements.txt
   -e.[md]
 


### PR DESCRIPTION
Enables the standard persist_docs functional tests for the MotherDuck profile. The DuckLake-specific persist-docs transaction test remains skipped for MotherDuck.